### PR TITLE
[feature/40] Add rubocop extensions for minitest and rake

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,15 +7,16 @@ AllCops:
         - 'bin/**/*'
     NewCops: enable
 
+require:
+    - rubocop-minitest
+    - rubocop-performance
+    - rubocop-rake
+
 Layout/LineLength:
     Max: 120
 
 Metrics/BlockLength:
     Max: 70
-    Exclude:
-        - 'Rakefile'
-        - 'rakelib/**/*.rake'
-        - 'spec/**/*.rb'
 
 Metrics/MethodLength:
     Max: 20

--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,9 @@ group :development, :test do
   # Pry is a runtime developer console and IRB alternative with powerful introspection capabilities.
   gem 'pry', '~> 0.14.1'
   gem 'rubocop', '~> 1.23.0'
+  gem 'rubocop-minitest', require: false
   gem 'rubocop-performance', '~> 1.12', require: false
+  gem 'rubocop-rake', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,9 +86,13 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.13.0)
       parser (>= 3.0.1.1)
+    rubocop-minitest (0.16.0)
+      rubocop (>= 0.90, < 2.0)
     rubocop-performance (1.12.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
+    rubocop-rake (0.6.0)
+      rubocop (~> 1.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     tzinfo (2.0.4)
@@ -114,7 +118,9 @@ DEPENDENCIES
   rack-test (~> 1.1)
   rake (~> 13.0, >= 13.0.1)
   rubocop (~> 1.23.0)
+  rubocop-minitest
   rubocop-performance (~> 1.12)
+  rubocop-rake
   zeitwerk (~> 2.5)
 
 RUBY VERSION

--- a/lib/middlewares/logging.rb
+++ b/lib/middlewares/logging.rb
@@ -55,7 +55,7 @@ module Middlewares
     end
 
     def response_json?(headers)
-      headers['Content-Type'] =~ %r{application/json}
+      headers['Content-Type'].include? 'application/json'
     end
   end
 end

--- a/test/api/ping_spec.rb
+++ b/test/api/ping_spec.rb
@@ -19,7 +19,7 @@ describe PingController do
   it 'has a status 200 in the body' do
     get '/api/v1/ping'
     response = JSON.parse(last_response.body)
-    assert(response['status'] == 200)
+    assert_equal(200, response['status'])
   end
 
   it 'respond with a message' do
@@ -31,6 +31,6 @@ describe PingController do
   it 'respond with a Pong message' do
     get '/api/v1/ping'
     response = JSON.parse(last_response.body)
-    assert(response['message'] == 'Pong')
+    assert_equal('Pong', response['message'])
   end
 end


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
Add rubocop-minitest extension.
Add rubocop-rake extension.
Enable rubocop extensions.
Fix rubocop issues.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #40 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->

- [ ] New feature (a non-breaking change which adds functionality)
- [x] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] Maintenance task (such as Documentation, GitHub templates,..)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
